### PR TITLE
Add Kodi stub modules

### DIFF
--- a/xbmcaddon.py
+++ b/xbmcaddon.py
@@ -1,0 +1,12 @@
+class Addon:
+    def __init__(self):
+        self._settings = {
+            "email": "",
+            "password": ""
+        }
+
+    def getSetting(self, key):
+        return self._settings.get(key, "")
+
+    def setSetting(self, key, value):
+        self._settings[key] = value

--- a/xbmcgui.py
+++ b/xbmcgui.py
@@ -1,0 +1,18 @@
+class Dialog:
+    def input(self, message, type=None):
+        try:
+            return input(message + " ")
+        except EOFError:
+            return ""
+
+    def ok(self, title, message):
+        print(f"{title}: {message}")
+
+class ListItem:
+    def __init__(self, label):
+        self.label = label
+        self.context_items = []
+
+    def addContextMenuItems(self, items):
+        # store context menu items for debugging
+        self.context_items.extend(items)

--- a/xbmcplugin.py
+++ b/xbmcplugin.py
@@ -1,0 +1,13 @@
+import sys
+
+def addDirectoryItem(handle, url, listitem, isFolder):
+    print(f"addDirectoryItem: handle={handle}, url={url}, label={listitem.label}, isFolder={isFolder}")
+
+def endOfDirectory(handle):
+    print(f"endOfDirectory: handle={handle}")
+
+def setPluginCategory(handle, category):
+    print(f"setPluginCategory: handle={handle}, category={category}")
+
+def setContent(handle, content):
+    print(f"setContent: handle={handle}, content={content}")


### PR DESCRIPTION
## Summary
- add minimal `xbmcaddon`, `xbmcgui`, and `xbmcplugin` modules to allow running the addon outside Kodi

## Testing
- `python default.py 1 "" ""`


------
https://chatgpt.com/codex/tasks/task_e_686f9508aab88331bbd35b2b97e66c48