### PR TITLE
Bump addon version to 0.1.9

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.program.kodiman.jdownloader" version="0.1.8" name="kodiman.jdownloader.addon" provider-name="Kodiman Himself">
+<addon id="plugin.program.kodiman.jdownloader" version="0.1.9" name="kodiman.jdownloader.addon" provider-name="Kodiman Himself">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
     </requires>


### PR DESCRIPTION
## Summary
- Increment addon version to 0.1.9 in `addon.xml`
- Verify root menu entries by running `default.main()` with stubbed Kodi APIs

## Testing
- `python3 -m py_compile default.py`
- `python3 - <<'PY'
import types, sys
xbmcgui = types.SimpleNamespace(ListItem=lambda label: f'ListItem({label})', Dialog=lambda: None)
xbmcplugin = types.SimpleNamespace(
    setPluginCategory=lambda handle, category: print('setPluginCategory', handle, category),
    setContent=lambda handle, content: print('setContent', handle, content),
    addDirectoryItem=lambda handle, url, listitem, isFolder: print('addDirectoryItem', handle, url, listitem, isFolder),
    endOfDirectory=lambda handle: print('endOfDirectory', handle)
)
xbmcaddon = types.SimpleNamespace(Addon=lambda: types.SimpleNamespace(getSetting=lambda key: 'dummy'))
myjdapi = types.SimpleNamespace(Myjdapi=lambda: None)
sys.modules['xbmcgui']=xbmcgui
sys.modules['xbmcplugin']=xbmcplugin
sys.modules['xbmcaddon']=xbmcaddon
sys.modules['myjdapi']=myjdapi
import default
sys.argv=['default.py','1','']
default.main()
PY`

------
https://chatgpt.com/codex/tasks/task_e_68ba5aa243d883318b8eb7f92d3d9bb2