### PR TITLE
Refactor Kodi jDownloader addon core and bump version to 0.1.12

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.program.kodiman.jdownloader" version="0.1.9" name="kodiman.jdownloader.addon" provider-name="Kodiman Himself">
+<addon id="plugin.program.kodiman.jdownloader" version="0.1.12" name="kodiman.jdownloader.addon" provider-name="Kodiman Himself">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
     </requires>

--- a/addon.xml
+++ b/addon.xml
@@ -1,12 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.program.kodiman.jdownloader" version="0.1.12" name="kodiman.jdownloader.addon" provider-name="Kodiman Himself">
+<addon id="plugin.program.kodiman.jdownloader" version="4.0.0" name="Kodiman jDownloader" provider-name="Kodiman Himself">
     <requires>
         <import addon="xbmc.python" version="3.0.0"/>
     </requires>
-    <extension point="xbmc.python.pluginsource" library="default.py"/>
+    <extension point="xbmc.python.pluginsource" library="default.py">
+        <provides>executable</provides>
+    </extension>
     <extension point="xbmc.addon.metadata">
         <summary lang="de">Steuere jDownloader über Kodi</summary>
-        <description lang="de">Mit diesem Addon kannst du neue Downloads hinzufügen, den Status anzeigen sowie Downloads stoppen oder löschen.</description>
+        <description lang="de">Mit diesem Addon kannst du neue Downloads hinzufügen, den Status anzeigen sowie Downloads stoppen oder löschen. Benötigt myjdapi.</description>
         <platform>all</platform>
+        <assets>
+            <icon>resources/icon.png</icon>
+        </assets>
     </extension>
 </addon>

--- a/default.py
+++ b/default.py
@@ -3,125 +3,213 @@
 import sys
 import urllib.parse
 
+import myjdapi
 import xbmcaddon  # pylint: disable=import-error
 import xbmcgui  # pylint: disable=import-error
 import xbmcplugin  # pylint: disable=import-error
-import myjdapi
 
 ADDON = xbmcaddon.Addon()
-EMAIL = ADDON.getSetting("email")
-PASSWORD = ADDON.getSetting("password")
+
+
+def _get_credentials():
+    """Return the configured login credentials.
+
+    Raises a RuntimeError with a translated message if the credentials are
+    missing so the caller can display the error in a dialog.
+    """
+
+    email = ADDON.getSetting("email")
+    password = ADDON.getSetting("password")
+    if not email or not password:
+        raise RuntimeError(
+            "Bitte E-Mail-Adresse und Passwort in den Addon-Einstellungen hinterlegen."
+        )
+    return email, password
+
+
+def _build_url(base_url, **query):
+    """Create a plugin URL including the provided query arguments."""
+
+    if not query:
+        return base_url
+    return base_url + "?" + urllib.parse.urlencode(query)
+
+
+def _get_uuid(args):
+    """Return a validated UUID argument or show an error dialog."""
+
+    uuid = args.get("uuid", [""])[0].strip()
+    if not uuid:
+        xbmcgui.Dialog().ok("Fehler", "Download-ID fehlt oder ist ungültig.")
+        return None
+    return uuid
+
 
 def connect_to_jd():
     """Establish a connection to the first available jDownloader device."""
+
     jd = myjdapi.Myjdapi()
     jd.set_app_key("KodiAddon")
-    jd.connect(EMAIL, PASSWORD)
+    email, password = _get_credentials()
+    jd.connect(email, password)
     jd.update_devices()
     devices = jd.list_devices()
     if not devices:
         raise RuntimeError("Kein jDownloader-Gerät gefunden.")
     return jd.get_device(devices[0]["name"])
 
+
 def add_download():
     """Prompt for a link and send it to jDownloader."""
+
     link = xbmcgui.Dialog().input(
         "Download-Link eingeben",
         type=xbmcgui.INPUT_ALPHANUM,
     )
     if not link:
         return
+
     try:  # pylint: disable=broad-except
         device = connect_to_jd()
-        device.linkgrabber.add_links([
-            {
-                "autostart": True,
-                "packageName": "Kodi-Download",
-                "links": link,
-                "overwritePackagizerRules": True,
-            }
-        ])
-        xbmcgui.Dialog().ok(
-            "Erfolg", "Download-Link wurde an jDownloader gesendet."
+        device.linkgrabber.add_links(
+            [
+                {
+                    "autostart": True,
+                    "packageName": "Kodi-Download",
+                    "links": link,
+                    "overwritePackagizerRules": True,
+                }
+            ]
         )
+        xbmcgui.Dialog().ok("Erfolg", "Download-Link wurde an jDownloader gesendet.")
     except Exception as err:  # pylint: disable=broad-except
         xbmcgui.Dialog().ok("Fehler", str(err))
-def show_status():
+
+
+def show_status(base_url, handle):
     """Display the list of active downloads."""
+
+    if handle < 0:
+        xbmcgui.Dialog().ok("Fehler", "Ungültiger Plugin-Aufruf.")
+        return
+
     try:  # pylint: disable=broad-except
         device = connect_to_jd()
         downloads = device.downloads.query_links()
+
         if not downloads:
             xbmcgui.Dialog().ok("Status", "Keine aktiven Downloads gefunden.")
             return
 
-        handle = int(sys.argv[1])
         for dl in downloads:
             name = dl.get("name", "Unbenannt")
             status = dl.get("status", "Unbekannt")
             uuid = dl.get("uuid")
             loaded = dl.get("bytesLoaded", 0)
             total = dl.get("bytesTotal", 0)
-            progress = int(min(loaded / total, 1.0) * 100) if total > 0 else 0
+            try:
+                progress = int(min(float(loaded) / float(total), 1.0) * 100)
+            except (TypeError, ZeroDivisionError):
+                progress = 0
+
             label = f"{name} - {progress}% - {status}"
             li = xbmcgui.ListItem(label)
-            li.addContextMenuItems([
-                ("Download stoppen", f"RunPlugin({sys.argv[0]}?action=stop&uuid={uuid})"),
-                ("Download löschen", f"RunPlugin({sys.argv[0]}?action=delete&uuid={uuid})"),
-            ])
-            xbmcplugin.addDirectoryItem(handle, sys.argv[0] + "?action=nop", li, False)
+            if uuid:
+                stop_url = _build_url(base_url, action="stop", uuid=uuid)
+                delete_url = _build_url(base_url, action="delete", uuid=uuid)
+                li.addContextMenuItems(
+                    [
+                        ("Download stoppen", f"RunPlugin({stop_url})"),
+                        ("Download löschen", f"RunPlugin({delete_url})"),
+                    ]
+                )
+            xbmcplugin.addDirectoryItem(handle, _build_url(base_url, action="nop"), li, False)
 
         xbmcplugin.endOfDirectory(handle)
     except Exception as err:  # pylint: disable=broad-except
         xbmcgui.Dialog().ok("Fehler", str(err))
+
+
+def _parse_request():
+    """Return base URL, handle and parsed query parameters for the call."""
+
+    base_url = sys.argv[0] if sys.argv else ""
+    try:
+        handle = int(sys.argv[1])
+    except (IndexError, ValueError, TypeError):
+        handle = -1
+
+    raw_query = sys.argv[2] if len(sys.argv) > 2 else ""
+    query_string = raw_query[1:] if raw_query.startswith("?") else raw_query
+    args = urllib.parse.parse_qs(query_string)
+    return base_url, handle, args
+
+
 def stop_download(uuid):
     """Stop a download by UUID."""
+
     try:  # pylint: disable=broad-except
         device = connect_to_jd()
         device.downloads.set_enabled(False, [uuid], [])
         xbmcgui.Dialog().ok("Aktion", "Download wurde gestoppt.")
     except Exception as err:  # pylint: disable=broad-except
         xbmcgui.Dialog().ok("Fehler", str(err))
+
+
 def delete_download(uuid):
     """Remove a download by UUID."""
+
     try:  # pylint: disable=broad-except
         device = connect_to_jd()
         device.downloads.remove_links([uuid], [])
         xbmcgui.Dialog().ok("Aktion", "Download wurde gelöscht.")
     except Exception as err:  # pylint: disable=broad-except
         xbmcgui.Dialog().ok("Fehler", str(err))
+
+
 def main():
     """Addon entry point."""
-    handle = int(sys.argv[1])
-    args = urllib.parse.parse_qs(sys.argv[2][1:])
+
+    base_url, handle, args = _parse_request()
     action = args.get("action", [None])[0]
 
     if action == "add":
         add_download()
     elif action == "status":
-        show_status()
+        show_status(base_url, handle)
     elif action == "stop":
-        stop_download(args.get("uuid", [""])[0])
+        uuid = _get_uuid(args)
+        if uuid:
+            stop_download(uuid)
     elif action == "delete":
-        delete_download(args.get("uuid", [""])[0])
+        uuid = _get_uuid(args)
+        if uuid:
+            delete_download(uuid)
+    elif action == "nop":
+        return
     else:
+        if handle < 0:
+            xbmcgui.Dialog().ok("Fehler", "Ungültiger Plugin-Aufruf.")
+            return
+
         xbmcplugin.setPluginCategory(handle, "jDownloader")
         xbmcplugin.setContent(handle, "files")
 
         xbmcplugin.addDirectoryItem(
             handle,
-            url=sys.argv[0] + "?action=add",
+            url=_build_url(base_url, action="add"),
             listitem=xbmcgui.ListItem("Neuen Download hinzufügen"),
             isFolder=False,
         )
         xbmcplugin.addDirectoryItem(
             handle,
-            url=sys.argv[0] + "?action=status",
+            url=_build_url(base_url, action="status"),
             listitem=xbmcgui.ListItem("Download-Status anzeigen"),
             isFolder=True,
         )
 
         xbmcplugin.endOfDirectory(handle)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
### Motivation
- Improve robustness and user feedback by validating configured credentials and request parameters before attempting API calls.
- Simplify URL and request handling for plugin navigation and context menu actions to avoid constructing raw query strings inline.
- Fix progress calculation edge cases and make the main entrypoint easier to follow by splitting responsibilities into small helper functions.

### Description
- Bumped addon version in `addon.xml` from `0.1.9` to `0.1.12`.
- Reorganized `default.py` by moving the `myjdapi` import to the top and introducing helper functions `
_get_credentials`, `_build_url`, `_get_uuid`, and `_parse_request` to centralize credential retrieval, URL construction, UUID validation, and request parsing.
- Updated `connect_to_jd` to use `
_get_credentials` and kept device selection logic, and updated `add_download` to maintain previous behavior with improved structure.
- Changed `show_status` to accept `base_url` and `handle`, added robust progress computation with exception handling, and build plugin action URLs via `_build_url`; added checks for valid UUIDs before adding context menu items.
- Updated `main` to use `_parse_request`, route actions with UUID validation for `stop` and `delete`, handle `nop`, and use `_build_url` when creating directory items.

### Testing
- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_68cb6f0551408331915875fe3bc1e550)

## Summary by Sourcery

Refactor the Kodi jDownloader addon core to centralize request/credential handling and improve robustness of navigation and download management.

Bug Fixes:
- Prevent runtime errors from missing credentials, invalid plugin handles, malformed UUIDs, and progress calculation edge cases during addon usage.

Enhancements:
- Introduce helper utilities for credential retrieval, URL construction, UUID validation, and request parsing to simplify the main addon entrypoint and plugin navigation.
- Harden download status listing with safer progress calculation, argument validation, and conditional context menu creation.
- Improve plugin routing by validating handles and UUIDs, adding a no-op action, and using structured URLs for all actions instead of raw query strings.

Build:
- Bump addon version in addon.xml from 0.1.9 to 0.1.12.